### PR TITLE
Fe fix/whole css fixed

### DIFF
--- a/client/jsconfig.json
+++ b/client/jsconfig.json
@@ -3,6 +3,4 @@
     "baseUrl": "src"
   },
   "includes": ["src"]
-  // "paths": {
-  //   "@/*": ["src/*"]
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,3 +1,4 @@
+export default App;
 import GlobalStyle from "@/styles/global";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import LoginPage from "@/pages/Login";
@@ -14,28 +15,23 @@ import EditProfilePage from "@/pages/EditProfile/EditProfile";
 const router = createBrowserRouter([
   {
     path: "/",
+    element: <Home />,
+  },
+  {
+    path: "Questions/Ask/",
+    element: <QuestionWrite />,
+  },
+  {
+    path: "Questions/",
     element: <Root />,
     children: [
       {
-        path: "/",
-        element: <Home />,
-      },
-
-      {
-        path: "Questions/List",
+        path: "List/",
         element: <QuestionList />,
       },
       {
-        path: "Questions/:questionId",
+        path: ":questionId/",
         element: <QuestionDetail />,
-      },
-      {
-        path: "/MyPage",
-        element: <MyPage />,
-      },
-      {
-        path: "/MyPage/EditProfile",
-        element: <EditProfilePage />,
       },
       {
         path: "*",
@@ -44,16 +40,30 @@ const router = createBrowserRouter([
     ],
   },
   {
-    path: "Questions/Ask",
-    element: <QuestionWrite />,
+    path: "MyPage/",
+    element: <Root />,
+    children: [
+      {
+        path: "",
+        element: <MyPage />,
+      },
+      {
+        path: "EditProfile/",
+        element: <EditProfilePage />,
+      },
+    ],
   },
   {
-    path: "Login",
+    path: "Login/",
     element: <LoginPage />,
   },
   {
-    path: "SignUp",
+    path: "SignUp/",
     element: <SignUpPage />,
+  },
+  {
+    path: "*",
+    element: <NotFound />,
   },
 ]);
 
@@ -65,5 +75,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,3 @@
-export default App;
 import GlobalStyle from "@/styles/global";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import LoginPage from "@/pages/Login";
@@ -75,3 +74,5 @@ function App() {
     </>
   );
 }
+
+export default App;

--- a/client/src/components/EditProfile/DeleteProfile.jsx
+++ b/client/src/components/EditProfile/DeleteProfile.jsx
@@ -23,7 +23,7 @@ const DeleteProfileForm = () => {
       <DeleteContainer>
         <DeleteTxtContainer>
           <p>
-            Before confirming that you would like your profile deleted, we'd
+            Before confirming that you would like your profile deleted, we{"'"}d
             like to take a moment to explain the implications of deletion:{" "}
           </p>
           <ul>
@@ -43,8 +43,8 @@ const DeleteProfileForm = () => {
           <p>
             Confirming deletion will only delete your profile on Stack Overflow
             - it will not affect any of your other profiles on the Stack
-            Exchange network. If you want to delete multiple profiles, you'll
-            need to visit each site separately and request deletion of those
+            Exchange network. If you want to delete multiple profiles, you{"'"}
+            ll need to visit each site separately and request deletion of those
             individual profiles.{" "}
           </p>
           <AgreeFormContainer>

--- a/client/src/components/EditProfile/DeleteProfile.jsx
+++ b/client/src/components/EditProfile/DeleteProfile.jsx
@@ -6,7 +6,7 @@ import {
   AgreeFormContainer,
   CheckboxContainer,
   DeleteBtn,
-} from "../../styles/DeleteProfileStyle";
+} from "@/styles/DeleteProfileStyle";
 
 const DeleteProfileForm = () => {
   const [isChecked, setIsChecked] = useState(false);

--- a/client/src/components/EditProfile/EditProfileNav.jsx
+++ b/client/src/components/EditProfile/EditProfileNav.jsx
@@ -3,7 +3,6 @@ import {
   NavActiveBtn,
   NavNormalBtn,
 } from "../../styles/EditProfile/EditProfileNavStyle";
-import { styled } from "styled-components";
 
 const EditProfileNav = () => {
   return (

--- a/client/src/components/EditProfile/EditProfileNav.jsx
+++ b/client/src/components/EditProfile/EditProfileNav.jsx
@@ -2,7 +2,7 @@ import {
   ProfileNav,
   NavActiveBtn,
   NavNormalBtn,
-} from "../../styles/EditProfile/EditProfileNavStyle";
+} from "@/styles/EditProfile/EditProfileNavStyle";
 
 const EditProfileNav = () => {
   return (

--- a/client/src/components/EditProfile/LinksForm.jsx
+++ b/client/src/components/EditProfile/LinksForm.jsx
@@ -4,7 +4,7 @@ import {
   LinksFormInput,
   LinksItemContainer,
   FlexItemContainer,
-} from "../../styles/EditProfile/LinksFormStyle";
+} from "@/styles/EditProfile/LinksFormStyle";
 
 const LinksForm = () => {
   return (

--- a/client/src/components/EditProfile/PrivateInfoForm.jsx
+++ b/client/src/components/EditProfile/PrivateInfoForm.jsx
@@ -5,7 +5,7 @@ import {
   PrivateTitleContainer,
   PrivateInformationForm,
   InformationTitle,
-} from "../../styles/EditProfile/PrivateInfoFormStyle";
+} from "@/styles/EditProfile/PrivateInfoFormStyle";
 
 const PrivateInfoForm = () => {
   return (

--- a/client/src/components/EditProfile/PublicInformation.jsx
+++ b/client/src/components/EditProfile/PublicInformation.jsx
@@ -7,7 +7,7 @@ import {
   EditInfoFormContainer,
   AboutMeContainer,
   AboutMeForm,
-} from "../../styles/EditProfile/PublicInformationStyle";
+} from "@/styles/EditProfile/PublicInformationStyle";
 
 const PublicInformation = () => {
   return (

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -48,9 +48,9 @@ const Header = () => {
       <Head>
         <div className="contents">
           <div className="Menubtn" onClick={change}>
-            <MenuLine age={-ageVal} y={ageVal} />
-            <MenuLine dp={ageVal && "none"} />
-            <MenuLine age={ageVal} y={-ageVal} />
+            <MenuLine $age={-ageVal} $y={ageVal} />
+            <MenuLine $dp={ageVal && "none"} />
+            <MenuLine $age={ageVal} $y={-ageVal} />
             {ageVal ? <Sidebar /> : null}
           </div>
 
@@ -108,18 +108,18 @@ const Header = () => {
                 <Link to={"/Login"}>
                   <TopBtn
                     onClick={changeInOutWhether}
-                    color="--powder-700"
-                    bgColor="--powder-100"
-                    hover="--powder-400"
+                    $color="--powder-700"
+                    $bgColor="--powder-100"
+                    $hover="--powder-400"
                   >
                     Log in
                   </TopBtn>
                 </Link>
                 <Link to={"/Signup"}>
                   <TopBtn
-                    color="--white"
-                    bgColor="--blue-500"
-                    hover="--blue-700"
+                    $color="--white"
+                    $bgColor="--blue-500"
+                    $hover="--blue-700"
                   >
                     Sign up
                   </TopBtn>

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -1,4 +1,3 @@
-import GlobalStyle from "../styles/global";
 import { LoginContainer } from "../styles/Login/LoginFormStyle";
 
 const LoginForm = () => {
@@ -6,7 +5,6 @@ const LoginForm = () => {
 
   return (
     <>
-      <GlobalStyle />
       <LoginContainer className="login-container">
         <div className="login-email">
           <label htmlFor="email">Email</label>

--- a/client/src/components/MyPage/MyPageContent.jsx
+++ b/client/src/components/MyPage/MyPageContent.jsx
@@ -1,5 +1,3 @@
-import { styled } from "styled-components";
-import GlobalStyle from "@/styles/global";
 import {
   MyPageContentContainer,
   PageContentContainerRight,
@@ -15,7 +13,6 @@ import {
 const MyPageContent = () => {
   return (
     <>
-      <GlobalStyle />
       <MyPageContentContainer>
         <PageContentContainerleft>
           <StatContent>

--- a/client/src/components/MyPage/MyPageContent.jsx
+++ b/client/src/components/MyPage/MyPageContent.jsx
@@ -8,7 +8,7 @@ import {
   HeadlineTxt,
   AboutMeBlock,
   StatContent,
-} from "../../styles/MyPage/MyPageContent";
+} from "@/styles/MyPage/MyPageContent";
 
 const MyPageContent = () => {
   return (

--- a/client/src/components/MyPage/MyPagePreview.jsx
+++ b/client/src/components/MyPage/MyPagePreview.jsx
@@ -15,7 +15,7 @@ import {
   WebLinkIcon,
   LocationIcon,
   EditIcon,
-} from "../../styles/MyPage/MyPagePreview";
+} from "@/styles/MyPage/MyPagePreview";
 import { RANDOM_AVATAR } from "@/config/config";
 
 const MyPagePreview = () => {

--- a/client/src/components/MyPage/MyPagePreview.jsx
+++ b/client/src/components/MyPage/MyPagePreview.jsx
@@ -1,6 +1,4 @@
 import { Link } from "react-router-dom";
-
-import GlobalStyle from "@/styles/global";
 import {
   MyPageProfileContainer,
   MyPageProfilelayout,
@@ -23,7 +21,6 @@ import { RANDOM_AVATAR } from "@/config/config";
 const MyPagePreview = () => {
   return (
     <>
-      <GlobalStyle />
       <MyPageProfileContainer>
         <MyPageProfilelayout>
           <ProfileImageContainer>

--- a/client/src/components/MyPage/MyPageTap.jsx
+++ b/client/src/components/MyPage/MyPageTap.jsx
@@ -2,7 +2,7 @@ import {
   MyPageTapContainer,
   ActiveBtn,
   NormalBtn,
-} from "../../styles/MyPage/MyPageTapStyle";
+} from "@/styles/MyPage/MyPageTapStyle";
 
 const MyPageTap = () => {
   return (

--- a/client/src/components/MyPage/MyPageTap.jsx
+++ b/client/src/components/MyPage/MyPageTap.jsx
@@ -1,4 +1,3 @@
-import { styled } from "styled-components";
 import {
   MyPageTapContainer,
   ActiveBtn,

--- a/client/src/components/QuestionWrite/WriteLayout.jsx
+++ b/client/src/components/QuestionWrite/WriteLayout.jsx
@@ -3,7 +3,6 @@ import iconWrite from "@/assets/image/iconWrite.png";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import {
-  Div,
   HeadlineDiv,
   Notice,
   Write,
@@ -18,7 +17,7 @@ const WriteLayout = () => {
     <Background>
       <Header />
       <div>
-        <Div>
+        <div>
           <HeadlineDiv>
             <h1>Ask a public question</h1>
             <img src={background} />
@@ -99,7 +98,7 @@ const WriteLayout = () => {
             <textarea></textarea>
           </Write>
           <PostButton>Post your question</PostButton>
-        </Div>
+        </div>
         <Footer />
       </div>
     </Background>

--- a/client/src/components/QuestionWrite/WriteLayout.jsx
+++ b/client/src/components/QuestionWrite/WriteLayout.jsx
@@ -3,7 +3,6 @@ import iconWrite from "@/assets/image/iconWrite.png";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import {
-  Background,
   Div,
   HeadlineDiv,
   Notice,
@@ -12,6 +11,7 @@ import {
   PostButton,
   Null,
 } from "@/styles/QuestionWriteStyle";
+import { Background } from "@/styles/RootStyle";
 
 const WriteLayout = () => {
   return (
@@ -94,40 +94,6 @@ const WriteLayout = () => {
               <p>
                 Introduce the problem and expand on what you put in the title.
                 Minimum 20 characters.
-              </p>
-            </div>
-            <textarea></textarea>
-          </Write>
-          <WriteGuide>
-            <h4>Expand on the problem</h4>
-            <div>
-              <img src={iconWrite} />
-              <div>
-                <p>
-                  Show what you’ve tried, tell us what happened, and why it
-                  didn’t meet your needs.
-                </p>
-                <p>
-                  Not all questions benefit from including code, but if your
-                  problem is better understood with code you’ve written, you
-                  should include a{" "}
-                  <span className="link">minimal, reproducible example.</span>
-                </p>
-                <p>
-                  Please make sure to post code and errors as text directly to
-                  the question (and <span className="link">not as images</span>
-                  ), and{" "}
-                  <span className="link">format them appropriately.</span>
-                </p>
-              </div>
-            </div>
-          </WriteGuide>
-          <Write>
-            <label>What did you try and what were you expecting?</label>
-            <div>
-              <p>
-                Describe what you tried, what you expected to happen, and what
-                actually resulted. Minimum 20 characters.
               </p>
             </div>
             <textarea></textarea>

--- a/client/src/components/SignupForm.jsx
+++ b/client/src/components/SignupForm.jsx
@@ -1,5 +1,3 @@
-
-import GlobalStyle from "../styles/global";
 import { SignUpContainer } from "../styles/Signup/SignupFormStyle";
 
 const SignUpForm = () => {
@@ -7,7 +5,6 @@ const SignUpForm = () => {
 
   return (
     <>
-      <GlobalStyle />
       <SignUpContainer>
         <div className="signup-displayname">
           <label htmlFor="displayname">Display name</label>

--- a/client/src/components/SignupForm.jsx
+++ b/client/src/components/SignupForm.jsx
@@ -1,4 +1,4 @@
-import { SignUpContainer } from "../styles/Signup/SignupFormStyle";
+import { SignUpContainer } from "@/styles/Signup/SignupFormStyle";
 
 const SignUpForm = () => {
   // const [loginInfo, setLoginInfo] = useState({ email: "", password: "" });

--- a/client/src/pages/EditProfile/EditProfile.jsx
+++ b/client/src/pages/EditProfile/EditProfile.jsx
@@ -1,4 +1,3 @@
-import styled from "styled-components";
 import {
   EditProfileContainer,
   FormContainer,

--- a/client/src/pages/EditProfile/EditProfile.jsx
+++ b/client/src/pages/EditProfile/EditProfile.jsx
@@ -6,12 +6,12 @@ import {
   BtnContainer,
   SaveBtn,
   CancelBtn,
-} from "../../styles/EditProfile/EditProfilePageStyle";
+} from "@/styles/EditProfile/EditProfilePageStyle";
 
-import EditProfileNav from "../../components/EditProfile/EditProfileNav";
-import LinksForm from "../../components/EditProfile/LinksForm";
-import PrivateInfoForm from "../../components/EditProfile/PrivateInfoForm";
-import PublicInformation from "../../components/EditProfile/PublicInformation";
+import EditProfileNav from "@/components/EditProfile/EditProfileNav";
+import LinksForm from "@/components/EditProfile/LinksForm";
+import PrivateInfoForm from "@/components/EditProfile/PrivateInfoForm";
+import PublicInformation from "@/components/EditProfile/PublicInformation";
 
 const EditProfilePage = () => {
   return (

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,18 +1,49 @@
+import { Link } from "react-router-dom";
+import { AiOutlineLock } from "react-icons/ai";
+import { BiSearchAlt } from "react-icons/bi";
 import { Contents } from "@/styles/Home/HomeStyle";
+import Footer from "@/components/Footer";
+import Header from "@/components/Header";
+import { Background } from "@/styles/RootStyle";
 
 const Home = () => {
   return (
     <>
-      <Contents>
-        <article>
-          <h1>FRONTEND</h1>
-          <div className="frontEnd"></div>
-        </article>
-        <article>
-          <h1>BACKEND</h1>
-          <div className="backEnd"></div>
-        </article>
-      </Contents>
+      <Header />
+      <Background>
+        <div>
+          <div>
+            <Contents>
+              <div>
+                <article>
+                  <div className="frontEnd">
+                    <BiSearchAlt size="62" color="#f2740d" />
+                    <h1>
+                      Find the best answer to your technical question, help
+                      others answer theirs
+                    </h1>
+                    <Link to="/Signup">
+                      <button>Join the community</button>
+                    </Link>
+                  </div>
+                </article>
+                <article>
+                  <div className="backEnd">
+                    <AiOutlineLock size="62" color="#0a95ff" />
+                    <h1>Team 502</h1>
+                    <button>Our Team</button>
+                  </div>
+                </article>
+              </div>
+              <h1>
+                Every <span className="highlight">developer</span> has atab open
+                to Stack Overflow
+              </h1>
+            </Contents>
+          </div>
+          <Footer />
+        </div>
+      </Background>
     </>
   );
 };

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import Header from "@/components/Header";
-import LoginForm from "../components/LoginForm";
-import { Icon, PageContainer } from "../styles/Login/LoginPageStyle";
+import LoginForm from "@/components/LoginForm";
+import { Icon, PageContainer } from "@/styles/Login/LoginPageStyle";
 const LoginPage = () => {
   return (
     <>

--- a/client/src/pages/MyPage/MyPage.jsx
+++ b/client/src/pages/MyPage/MyPage.jsx
@@ -1,11 +1,11 @@
-import MyPageTap from "../../components/MyPage/MyPageTap";
+import MyPageTap from "@/components/MyPage/MyPageTap";
+import MyPageContent from "@/components/MyPage/MyPageContent";
+import MyPagePreview from "@/components/MyPage/MyPagePreview";
 import { styled } from "styled-components";
-import MyPageContent from "../../components/MyPage/MyPageContent";
-import MyPagePreview from "../../components/MyPage/MyPagePreview";
 const MyPagePageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: calc(100vw - 40px);
   max-width: 1051px;
   height: 982px;
   /* border: 2px solid red; */

--- a/client/src/pages/NotFound.jsx
+++ b/client/src/pages/NotFound.jsx
@@ -1,5 +1,21 @@
+import Footer from "@/components/Footer";
+import Header from "@/components/Header";
+import { Div } from "@/styles/RootStyle";
+
 const NotFound = () => {
-  return <p>NotFound</p>;
+  return (
+    <>
+      <Header />
+      <Div>
+        <div>
+          <div>
+            <p>NotFound</p>
+          </div>
+          <Footer />
+        </div>
+      </Div>
+    </>
+  );
 };
 
 export default NotFound;

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,6 +1,6 @@
 import Header from "@/components/Header";
-import SignUpForm from "../components/SignupForm";
-import { PageContainer } from "../styles/Signup/SignupPageStyle";
+import SignUpForm from "@/components/SignupForm";
+import { PageContainer } from "@/styles/Signup/SignupPageStyle";
 
 const SignUpPage = () => {
   return (

--- a/client/src/styles/EditProfile/EditProfilePageStyle.jsx
+++ b/client/src/styles/EditProfile/EditProfilePageStyle.jsx
@@ -3,17 +3,16 @@ import { styled } from "styled-components";
 export const EditProfileContainer = styled.div`
   display: flex;
   flex-direction: row;
-  width: 100%;
+  width: calc(100vw - 40px);
   max-width: 1051px;
   height: 1359px;
   /* border: 2px solid red; */
-  padding: 24px;
 `;
 
 export const FormContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: calc(100% - 203px);
   max-width: 832px;
   height: 1358px;
   /* border:2px solid orange; */
@@ -22,8 +21,7 @@ export const FormContainer = styled.div`
 export const ProfileTitle = styled.div`
   justify-content: center;
   text-align: left;
-  width: 800px;
-
+  width: 100%;
   height: 48px;
   font-size: var(--fs-headline1);
   border-bottom: 1px solid var(--black-200);

--- a/client/src/styles/EditProfile/EditProfilePageStyle.jsx
+++ b/client/src/styles/EditProfile/EditProfilePageStyle.jsx
@@ -11,12 +11,12 @@ export const EditProfileContainer = styled.div`
 `;
 
 export const FormContainer = styled.div`
-display:flex;
-flex-direction:column;
-width:100%
-max-width: 832px;
-height:1358px;
-/* border:2px solid orange; */
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 832px;
+  height: 1358px;
+  /* border:2px solid orange; */
 `;
 
 export const ProfileTitle = styled.div`
@@ -50,16 +50,14 @@ export const EditFormContainer = styled.div`
 `;
 
 export const BtnContainer = styled.div`
-display:flex;
+  display: flex;
 
-  width:100%
-  max-width:840px;
-  height:46px;
+  width: 100%;
+  max-width: 840px;
+  height: 46px;
   /* border:1px solid red; */
 
   align-items: center;
-
-  
 `;
 
 export const SaveBtn = styled.button`

--- a/client/src/styles/EditProfile/PrivateInfoFormStyle.jsx
+++ b/client/src/styles/EditProfile/PrivateInfoFormStyle.jsx
@@ -8,14 +8,14 @@ export const InformationTitle = styled.div`
 `;
 
 export const PrivateInfoContainer = styled.div`
-display:flex;
-align-items:center;
-width:100%
-max-width:843px;
-height:107px;
-border: 1px solid var(--black-200);
-border-radius:10px;
-margin-bottom:60px;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 843px;
+  height: 107px;
+  border: 1px solid var(--black-200);
+  border-radius: 10px;
+  margin-bottom: 60px;
 `;
 
 export const PrivateInfoFormContainer = styled.div`

--- a/client/src/styles/HeaderStyle.jsx
+++ b/client/src/styles/HeaderStyle.jsx
@@ -41,13 +41,13 @@ export const Head = styled.header`
 `;
 
 export const MenuLine = styled.div`
-  display: ${(props) => props.dp};
+  display: ${(props) => props.$dp};
   margin: 2px;
   width: 20px;
   height: 3px;
   background-color: var(--black-300);
-  transform: rotate(${(props) => props.age}deg)
-    translate(0, ${(props) => props.y / 10}px);
+  transform: rotate(${(props) => props.$age}deg)
+    translate(0, ${(props) => props.$y / 10}px);
   transition: 0.1s;
 `;
 
@@ -173,10 +173,10 @@ export const TopBtn = styled.button`
   width: auto;
   min-width: 72px;
   height: 33px;
-  color: ${(props) => `var(${props.color})` || "var(--black)"};
-  background-color: ${(props) => `var(${props.bgColor})` || "var(--black)"};
+  color: ${(props) => `var(${props.$color})` || "var(--black)"};
+  background-color: ${(props) => `var(${props.$bgColor})` || "var(--black)"};
   &:hover {
-    background-color: ${(props) => `var(${props.hover})`};
+    background-color: ${(props) => `var(${props.$hover})`};
   }
 `;
 

--- a/client/src/styles/HeaderStyle.jsx
+++ b/client/src/styles/HeaderStyle.jsx
@@ -51,7 +51,7 @@ export const MenuLine = styled.div`
   transition: 0.1s;
 `;
 
-export const Logo = styled.a`
+export const Logo = styled.div`
   display: flex;
   flex: 0.5;
   justify-content: center;

--- a/client/src/styles/Home/HomeStyle.jsx
+++ b/client/src/styles/Home/HomeStyle.jsx
@@ -1,30 +1,89 @@
 import styled from "styled-components";
 
 export const Contents = styled.main`
+  margin: 28px;
+  width: calc(100vw - 96px);
+  border-radius: 8px;
+  padding: 32px 32px 128px 32px;
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  background-color: var(--black-700);
+
+  & > div {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+
+    @media (max-width: 640px) {
+      flex-direction: column;
+      align-items: center;
+    }
+  }
 
   article {
+    margin: 16px;
+    width: 100%;
+
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 200px 50px;
+    margin-bottom: 12px;
+
+    &:first-child > div {
+      background-color: var(--orange-100);
+
+      button {
+        background-color: var(--orange-500);
+      }
+    }
+
+    &:last-child > div {
+      background-color: var(--blue-100);
+
+      button {
+        background-color: var(--blue-500);
+      }
+    }
+
+    & > div {
+      width: 100%;
+      height: 300px;
+      border-radius: 8px;
+      padding: 24px;
+      font-size: var(--fs-headline2);
+      text-align: center;
+      color: var(--black-800);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: space-between;
+
+      h1 {
+        margin: 0 39px;
+      }
+
+      button {
+        width: 210px;
+        height: 43px;
+        border-radius: 8px;
+        margin-bottom: 24px;
+        color: var(--white);
+        font-size: var(--fs-base);
+        cursor: pointer;
+      }
+    }
   }
 
-  h1 {
-  }
+  & > h1 {
+    padding: 64px 100px;
+    font-size: var(--fs-big);
+    color: var(--white);
+    font-weight: 800;
+    text-align: center;
 
-  .frontEnd {
-    width: 300px;
-    height: 300px;
-    background-color: var(--black);
-    border-radius: 30px;
-  }
-
-  .backEnd {
-    width: 300px;
-    height: 300px;
-    background-color: var(--black);
-    border-radius: 30px;
+    span.highlight {
+      color: var(--orange);
+    }
   }
 `;

--- a/client/src/styles/MyPage/MyPageContent.jsx
+++ b/client/src/styles/MyPage/MyPageContent.jsx
@@ -16,14 +16,14 @@ export const PageContentContainerleft = styled.div`
 
 export const PageContentContainerRight = styled.div`
   display: block;
-  width: 783px;
+  width: calc(100% - 245px);
   height: 791px;
   /* border: 2px solid mediumseagreen; */
 `;
 
 export const PageContentGrid = styled.div`
   display: grid;
-  width: 783px;
+  width: calc(100% - 245px);
   height: 791px;
   /* border: 2px solid crimson; */
 `;
@@ -36,7 +36,7 @@ export const StatContent = styled.div`
 
 export const AboutMeBlock = styled.div`
   display: block;
-  width: 783px;
+  width: calc(100% - 245px);
   height: 87px;
   /* border: 2px solid crimson; */
 `;
@@ -47,13 +47,13 @@ export const HeadlineTxt = styled.div`
 `;
 
 export const BadgeBlock = styled.div`
-  width: 783px;
+  width: calc(100% - 245px);
   height: 223px;
   /* border: 2px solid blue; */
 `;
 
 export const PostsBlock = styled.div`
-  width: 783px;
+  width: calc(100% - 245px);
   height: 434px;
   /* border: 2px solid orange; */
 `;

--- a/client/src/styles/MyPage/MyPagePreview.jsx
+++ b/client/src/styles/MyPage/MyPagePreview.jsx
@@ -4,7 +4,6 @@ export const MyPageProfileContainer = styled.div`
   position: static;
   display: relative;
   width: 100%;
-  max-width: 1037px;
   height: 144px;
 `;
 
@@ -13,7 +12,6 @@ export const MyPageProfilelayout = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   width: 100%;
-  max-width: 1066px;
   height: 144px;
   margin-bottom: var(--su16) !important;
   /* border: 2px solid red; */
@@ -34,13 +32,11 @@ export const ProfileImage = styled.img`
 export const StatusContainer = styled.div`
   justify-content: left;
   display: block;
-  width: 480px;
+  width: calc(100% - 238px);
   height: 123px;
 `;
 
 export const EditProfileBtn = styled.div`
-  margin-left: auto;
-  margin-right: 10px;
   justify-content: center;
   align-items: center;
   display: flex;

--- a/client/src/styles/MyPage/MyPagePreview.jsx
+++ b/client/src/styles/MyPage/MyPagePreview.jsx
@@ -47,7 +47,6 @@ export const EditProfileBtn = styled.div`
   width: 100px;
   height: 35px;
   border-radius: 5px;
-  font-size: var(--)
   cursor: pointer;
   border: 1px solid var(--black-500);
 `;

--- a/client/src/styles/QuestionDetail/QuestionStyle.jsx
+++ b/client/src/styles/QuestionDetail/QuestionStyle.jsx
@@ -6,6 +6,10 @@ export const Div = styled.div`
   @media (max-width: 1265px) {
     width: calc(100vw - 214px);
   }
+
+  @media (max-width: 640px) {
+    width: 100%;
+  }
 `;
 
 export const ArticleMoreData = styled.div`

--- a/client/src/styles/QuestionList/LayoutStyle.jsx
+++ b/client/src/styles/QuestionList/LayoutStyle.jsx
@@ -23,7 +23,7 @@ export const ListDiv = styled(Flex)`
   }
 
   @media (max-width: 980px) {
-    width: calc(100vw);
+    width: 100%;
     flex-direction: column;
   }
 `;
@@ -59,7 +59,7 @@ export const ItemDiv = styled(Flex)`
     }
 
     @media (max-width: 980px) {
-      width: calc(100% - 16px);
+      width: calc(100% - 40px);
       flex-direction: row;
       justify-content: left;
     }

--- a/client/src/styles/QuestionWriteStyle.jsx
+++ b/client/src/styles/QuestionWriteStyle.jsx
@@ -1,7 +1,5 @@
 import { styled } from "styled-components";
 
-export const Div = styled.div``;
-
 export const Null = styled.div`
   width: 1px;
   height: 1px;

--- a/client/src/styles/QuestionWriteStyle.jsx
+++ b/client/src/styles/QuestionWriteStyle.jsx
@@ -1,34 +1,6 @@
 import { styled } from "styled-components";
 
-export const Background = styled.div`
-  background-color: var(--black-025);
-  width: 100vw;
-  height: 100vh;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  & > div {
-    display: flex;
-    width: 100%;
-    height: max-content;
-    flex-direction: column;
-    align-items: center;
-  }
-`;
-
-export const Div = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row-reverse;
-  justify-content: flex-end;
-  width: 1216px;
-  height: max-content;
-  margin-top: 60px;
-  margin-bottom: 48px;
-  padding: 0 24px 24px 24px;
-`;
+export const Div = styled.div``;
 
 export const Null = styled.div`
   width: 1px;

--- a/client/src/styles/RootStyle.jsx
+++ b/client/src/styles/RootStyle.jsx
@@ -16,6 +16,40 @@ export const Div = styled.div`
 
     & > div:first-child {
       padding: 20px;
+      min-height: calc(100vh - 382px);
+    }
+  }
+`;
+
+export const Background = styled.div`
+  background-color: var(--black-025);
+  width: 100vw;
+  height: 100vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  & > div {
+    display: flex;
+    width: 100%;
+    height: max-content;
+    flex-direction: column;
+    align-items: center;
+
+    & > div:first-child {
+      padding: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: row-reverse;
+      justify-content: flex-end;
+      width: 100%;
+      max-width: 1216px;
+      height: max-content;
+      min-height: calc(100vh - 382px);
+      margin-top: 60px;
+      margin-bottom: 48px;
+      padding: 0 24px 24px 24px;
     }
   }
 `;

--- a/client/src/styles/global.jsx
+++ b/client/src/styles/global.jsx
@@ -68,6 +68,7 @@ const GlobalStyle = createGlobalStyle`
     --fs-headline1: 27px;
     --fs-headline2: 21px;
     --fs-headline3: 17px;
+    --fs-big: 55px;
   }
 
   * {


### PR DESCRIPTION
1. route를 정리했습니다.
2. Home화면의 css를 일부 꾸몄습니다.
3. 각 컴포넌트 내에서 호출하고 사용하지 않는 import를 지웠습니다.
4. styled-components에 props를 보낼 때엔 attribute 앞에 $기호를 붙여야 경고 console이 뜨지 않더라고요...
(참고자료: https://velog.io/@mintmin0320/styled-components-it-looks-like-an-unknown-prop-%EB%AC%B8%EC%A0%9C%EA%B0%80-%EB%90%98%EB%8A%94-props-is-being-sent-through-to-the-DOM-which-will-likely-trigger-a-React-console-error.-%EA%B2%BD%EA%B3%A0-%ED%95%B4%EA%B2%B0%EB%B2%95)
5. GlobalStyle은 프로그램 최상단, 즉 App컴포넌트에서 1회 호출하는 것으로 충분합니다. 하위 컴포넌트에서 호출된 GlobalStyle을 지웠습니다.
6. 반응형이 조금 더 잘 작동하도록 width간격을 조정하고 일부 media query를 추가하였습니다.
7. a 태그 내에서 a태그를 다시 호출하였다는 에러가 뜨더라고요. styled-components를 만들때 a태그로 만든게 원인이며, src로 경로를 부여하여 하이퍼링크를 만들어야 할 때 외엔 a태그 사용을 자제해주세요.

중간중간 commit을 나누는걸 빼먹어 첫 commit이 위 사항을 전부 반영하여 사이즈가 상당히 커졌네요...